### PR TITLE
Fix a bug when trying to destroy resources using the `remote` backend

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -89,15 +89,15 @@ _cmd_apply () {
 }
 _cmd_plan_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_validate
+    _runcmd "$TERRAFORM" plan "${VARFILE_ARG[@]}" -destroy "${PLANDESTROY_ARGS[@]}
+}
+_cmd_destroy () {
+    [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init
     if [ "${USE_PLANFILE:-0}" = "0" ] ; then
         _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}"
     else
         _runcmd "$TERRAFORM" apply "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
     fi
-}
-_cmd_destroy () {
-    [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init
-    ([ "${USE_PLANFILE:-0}" = "0" ] && _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}") || _runcmd "$TERRAFORM" plan "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
 }
 # Validate doesn't require 'init' to check the .tf files syntax, but it does
 # require init once it gets to the providers

--- a/terraformsh
+++ b/terraformsh
@@ -89,7 +89,11 @@ _cmd_apply () {
 }
 _cmd_plan_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_validate
-    _runcmd "$TERRAFORM" plan "${VARFILE_ARG[@]}" -destroy "${PLANDESTROY_ARGS[@]}"
+    if [ "${USE_PLANFILE:-0}" = "0" ] ; then
+        _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}"
+    else
+        _runcmd "$TERRAFORM" apply "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
+    fi
 }
 _cmd_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init

--- a/terraformsh
+++ b/terraformsh
@@ -89,7 +89,7 @@ _cmd_apply () {
 }
 _cmd_plan_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_validate
-    _runcmd "$TERRAFORM" plan "${VARFILE_ARG[@]}" -destroy "${PLANDESTROY_ARGS[@]}
+    _runcmd "$TERRAFORM" plan "${VARFILE_ARG[@]}" -destroy "${PLANDESTROY_ARGS[@]}"
 }
 _cmd_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init

--- a/terraformsh
+++ b/terraformsh
@@ -93,7 +93,7 @@ _cmd_plan_destroy () {
 }
 _cmd_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init
-    _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
+    ([ "${USE_PLANFILE:-0}" = "0" ] && _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}") || _runcmd "$TERRAFORM" plan "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
 }
 # Validate doesn't require 'init' to check the .tf files syntax, but it does
 # require init once it gets to the providers

--- a/terraformsh
+++ b/terraformsh
@@ -93,7 +93,7 @@ _cmd_plan_destroy () {
 }
 _cmd_destroy () {
     [ "${NO_DEP_CMDS:-0}" = "0" ] && _cmd_init
-    _runcmd "$TERRAFORM" apply "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
+    _runcmd "$TERRAFORM" destroy "${DESTROY_ARGS[@]}" && rm -f "$TF_DESTROY_PLANFILE"
 }
 # Validate doesn't require 'init' to check the .tf files syntax, but it does
 # require init once it gets to the providers


### PR DESCRIPTION
In order to avoid executing and apply command to remote `terraform` cloud workspace when trying to destroy resources, changing the destroy function to use destroy sub command instead of apply will avoid this issue when trying to destroy with `-P` flag which is the only way to deal with the remote backend since it currently does not support saving plan files which is the default behavior for `terraformsh` right now.

