### PR TITLE
Fix location of default plan file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 on:
-  push:
+  #push:
   pull_request:
     branches: [ main ]
 

--- a/terraformsh
+++ b/terraformsh
@@ -305,9 +305,9 @@ _final_vars () {
     _tf_set_datadir
 
     # Override these to change the name of the plan files
-    TF_PLANFILE="${TF_PLANFILE:-$(pwd)/tf.$TF_DD_UNIQUE_NAME.plan}"
-    TF_DESTROY_PLANFILE="${TF_DESTROY_PLANFILE:-$(pwd)/tf-destroy.$TF_DD_UNIQUE_NAME.plan}"
-    TF_BOOTSTRAP_PLANFILE="${TF_BOOTSTRAP_PLANFILE:-$(pwd)/tf-bootstrap.$TF_DD_UNIQUE_NAME.plan}"
+    TF_PLANFILE="${TF_PLANFILE:-${TERRAFORM_PWD}/tf.$TF_DD_UNIQUE_NAME.plan}"
+    TF_DESTROY_PLANFILE="${TF_DESTROY_PLANFILE:-${TERRAFORM_PWD}/tf-destroy.$TF_DD_UNIQUE_NAME.plan}"
+    TF_BOOTSTRAP_PLANFILE="${TF_BOOTSTRAP_PLANFILE:-${TERRAFORM_PWD}/tf-bootstrap.$TF_DD_UNIQUE_NAME.plan}"
 
     if [ "$USE_PLANFILE" -eq 1 ] ; then
         PLAN_ARGS+=("-out=$TF_PLANFILE")

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -27,4 +27,29 @@ _t_plan_files_enabled () {
     fi
 }
 
-ext_tests="plan_files_enabled"
+# Test that plan files show up when we use CD_DIR= option
+_t_plan_files_enabled_cd_dir () {
+    pwd
+    cp -a "$testsh_pwd/tests/null-resource-hello-world.tf" "$tmp/"
+    mkdir -p "$tmp/rundir"
+    cd "$tmp"/rundir
+    if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tf" plan
+    then
+
+        TERRAFORM_PWD="$(pwd)"
+        TERRAFORM_MODULE_PWD="$tmp/null-resource-hello-world.tf"
+
+        # The current method of calculating plan file names (copy-paste from terraformsh):
+        TF_DD_UNIQUE_NAME="$(printf "%s\n%s\n" "$TERRAFORM_PWD" "$TERRAFORM_MODULE_PWD" | md5sum - | awk '{print $1}' | cut -b 1-10)"
+
+        echo "TF_DD_UNIQUE_NAME=$TF_DD_UNIQUE_NAME"
+
+        if [ ! -e "tf.$TF_DD_UNIQUE_NAME.plan" ] ; then
+            echo "$base_name: ERROR: No plan file found!"
+            ls -la
+            return 1
+        fi
+    fi
+}
+
+ext_tests="plan_files_enabled plan_files_enabled_cd_dir"

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -27,6 +27,32 @@ _t_plan_files_disabled () {
     fi
 }
 
+# Test that plan files don't show up when CD_DIR= is used
+_t_plan_files_disabled_cd_dir () {
+    pwd
+    cp -a "$testsh_pwd/tests/null-resource-hello-world.tf" "$tmp/"
+    mkdir -p "$tmp/rundir"
+    cd "$tmp"/rundir
+    if      $testsh_pwd/terraformsh -c "$tmp/null-resource-hello-world.tf" -P plan
+    then
+
+        TERRAFORM_PWD="$(pwd)"
+        TERRAFORM_MODULE_PWD="$tmp/null-resource-hello-world.tf"
+
+        # The current method of calculating plan file names (copy-paste from terraformsh):
+        TF_DD_UNIQUE_NAME="$(printf "%s\n%s\n" "$TERRAFORM_PWD" "$TERRAFORM_MODULE_PWD" | md5sum - | awk '{print $1}' | cut -b 1-10)"
+
+        echo "TF_DD_UNIQUE_NAME=$TF_DD_UNIQUE_NAME"
+
+        if [ -e "tf.$TF_DD_UNIQUE_NAME.plan" ] ; then
+            echo "$base_name: ERROR: Plan file found but none expected!"
+            ls -la
+            return 1
+        fi
+    fi
+}
+
+
 # Test that plan files don't show up when using destroy.
 # 
 # This also tests whether 'destroy' works as expected when plan files are disabled:
@@ -63,4 +89,4 @@ _t_plan_files_disabled_destroy () {
     fi
 }
 
-ext_tests="plan_files_disabled plan_files_disabled_destroy"
+ext_tests="plan_files_disabled plan_files_disabled_cd_dir plan_files_disabled_destroy"


### PR DESCRIPTION
I'm not sure when this happened, but the location of the plan file changed from
the current directory you run terraformsh from, to the root module directory.

I chose to put it in the current directory so that it's both easier to identify
plan files when they're created, and to keep the module directory free of
extraneous/temporary files.

This will be a breaking change for those who expect the previous behavior
(plan files going into the module directory)