### PR TITLE
New feature! Don't remove temporary TF_DATA_DIR

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -45,6 +45,9 @@ _usage () {
     -N              Dry-run mode (don't execute anything).
                     (config: DRYRUN=1)
 
+    -n              Don't remove the temporary TF_DATA_DIR.
+                    (config: NO_CLEANUP_TMP=1)
+
     -v              Verbose mode.
                     (config: DEBUG=1)
 
@@ -257,8 +260,16 @@ _cmd_aws_bootstrap () {
 
     _runcmd "$TERRAFORM" init "${INIT_ARGS[@]}" "${BACKENDVARFILE_ARG[@]}"
 }
-_cleanup_tmp () { 
-    if [ -n "${TF_TMPDIR:-}" ]; then rm -rf "$TF_TMPDIR"; fi
+_cleanup_tmp () {
+    if [ $? -ne 0 ] ; then
+        echo "$0: Error detected; not removing '${TF_TMPDIR:-}'"
+    else
+        if [ "${NO_CLEANUP_TMP:-0}" = "1" ] ; then
+            echo "$0: Not removing temporary TF_DATA_DIR '${TF_TMPDIR:-}'"
+        elif [ -n "${TF_TMPDIR:-}" ] ; then
+            rm -rf "$TF_TMPDIR"
+        fi
+    fi
 }
 _tf_ver () {
     local tf_ver
@@ -456,7 +467,7 @@ declare -a CMDS=() CONF_FILE=() OPTS=()
 
 _default_vars
 
-while getopts "f:b:C:c:E:IPDNhv" args ; do
+while getopts "f:b:C:c:E:IPDNnhv" args ; do
     case $args in
         f)  VARFILES+=("$(_readlinkf "$OPTARG")") ;;
         b)  BACKENDVARFILES+=("$(_readlinkf "$OPTARG")") ;;
@@ -467,6 +478,7 @@ while getopts "f:b:C:c:E:IPDNhv" args ; do
         P)  USE_PLANFILE=0 ;;
         D)  NO_DEP_CMDS=1 ;;
         N)  DRYRUN=1 ;;
+        n)  NO_CLEANUP_TMP=1 ;;
         h)  SHOW_HELP=1 ;;
         v)  export DEBUG=1 ;;
         *)


### PR DESCRIPTION
I've found an interesting case where Terraform does something.... annoying.
That _never_ happens........

If you're applying a Lambda function and using:

```hcl
data "archive_file" "function_zip" {
  type = "zip"
  output_path = "${path.module}/file.zip"
}
```

Then the 'terraform plan' will make the ZIP file, but when you run
'terraform apply' later, the module path has been removed and replaced by the
dynamic TF_DATA_DIR function of terraformsh. So you end up not being able to
apply your Lambda because the zip file is gone.

I guess I can't fault Terraform for the user writing a file to the module path, but it
seems like there should already be a pattern for storing artifacts like this in the
plan file (at least) or better yet, the state file (because how else are you going to
ensure you're able to apply/revert the zip code you used before?).

This adds the option `-n` (NO_CLEANUP_TMP=1) which will prevent removing the
dynamic TF_DATA_DIR folder, so the .zip file created during 'terraform plan'
will remain for a 'terraform apply' later.

Also added some logic so that the _cleanup_tmp function will not remove the
temporary diretory if the last command failed, so you can troubleshoot the
failure. (I'm sure this is going to bite me in the ass later...)