### PR TITLE
Fix tests for Terraform version < 0.12

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,12 +21,28 @@ set -u
 
 # Don't modify anything after here
 
+ # Function to delete version-specific tf file that might not be needed based on the TF version
+_check_and_delete_provider_files() {
+    local folder="$1"
+    local tf_ver="$2"
+    if [ ! -z "$folder" ] && [ -d "$folder" ]; then
+        # Based on the TF version, keep or delete specific files
+        if [ "$tf_ver" = "pre-0.12" ]; then
+            find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Keeping version-specific provider file: {}" \;
+        else
+            find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Removing unnecessary provider file: {}" \; -delete
+        fi
+    fi
+}
+
 ### _main() - run the tests
 ### Arguments:
 ###     TESTPATH        -   A file path ending with '.t'
 _main () {
     _fail=0 _pass=0 _failedtests=""
     testsh_pwd="$(pwd)"
+
+    . "tests/0000-pre-req-detect-tf-version.sh"
 
     for i in "$@" ; do
 

--- a/tests/0000-pre-req-detect-tf-version.sh
+++ b/tests/0000-pre-req-detect-tf-version.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# vim: syntax=sh
+[ "${DEBUG:-0}" = "1" ] && set -x
+set -u
+
+# Detect terraform version (major + minor)
+TF_VER_FULL=$( terraform --version | grep '^Terraform v' | cut -d 'v' -f 2 )
+TF_VER_MAJOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $1}' )
+TF_VER_MINOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $2}' )
+
+# For Terraform < 0.12, the Terraform plugin declaration is different
+if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
+    TF_VER="pre-0.12"
+else
+    TF_VER="post-0.12"
+fi
+
+echo "Terraform Version: $TF_VER_FULL ($TF_VER)"

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -3,10 +3,31 @@
 [ "${DEBUG:-0}" = "1" ] && set -x
 set -u
 
+# Detect terraform version (major + minor)
+TF_VER_FULL=$( terraform --version | grep '^Terraform v' | cut -d 'v' -f 2 )
+TF_VER_MAJOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $1}' )
+TF_VER_MINOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $2}' )
+
+# For Terraform < 0.12, the Terraform plugin declaration is different
+if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
+    TF_VER="pre-0.12"
+else
+    TF_VER="post-0.12"
+fi
+
+echo "Terraform Version: $TF_VER_FULL ($TF_VER)"
+
 # Test that plan files show up
 _t_plan_files_enabled () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
+    # Optionally delete the null-provider tf file that we don't need
+    if [ $TF_VER = "pre-0.12" ]; then
+        echo "Using $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
+    else
+        echo "Deleting $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf (not needed)"
+        rm -f "$tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
+    fi
     cd "$tmp"/null-resource-hello-world.tfd
     if      $testsh_pwd/terraformsh plan
     then
@@ -31,6 +52,13 @@ _t_plan_files_enabled () {
 _t_plan_files_enabled_cd_dir () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
+    # Optionally delete the null-provider tf file that we don't need
+    if [ $TF_VER = "pre-0.12" ]; then
+        echo "Using $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
+    else
+        echo "Deleting $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf (not needed)"
+        rm -f "$tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
+    fi
     mkdir -p "$tmp/rundir"
     cd "$tmp"/rundir
     if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" plan

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -3,31 +3,11 @@
 [ "${DEBUG:-0}" = "1" ] && set -x
 set -u
 
-# Detect terraform version (major + minor)
-TF_VER_FULL=$( terraform --version | grep '^Terraform v' | cut -d 'v' -f 2 )
-TF_VER_MAJOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $1}' )
-TF_VER_MINOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $2}' )
-
-# For Terraform < 0.12, the Terraform plugin declaration is different
-if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
-    TF_VER="pre-0.12"
-else
-    TF_VER="post-0.12"
-fi
-
-echo "Terraform Version: $TF_VER_FULL ($TF_VER)"
-
 # Test that plan files show up
 _t_plan_files_enabled () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
-    # Optionally delete the null-provider tf file that we don't need
-    if [ $TF_VER = "pre-0.12" ]; then
-        echo "Using $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
-    else
-        echo "Deleting $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf (not needed)"
-        rm -f "$tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
-    fi
+    _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
     cd "$tmp"/null-resource-hello-world.tfd
     if      $testsh_pwd/terraformsh plan
     then
@@ -52,13 +32,7 @@ _t_plan_files_enabled () {
 _t_plan_files_enabled_cd_dir () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
-    # Optionally delete the null-provider tf file that we don't need
-    if [ $TF_VER = "pre-0.12" ]; then
-        echo "Using $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
-    else
-        echo "Deleting $tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf (not needed)"
-        rm -f "$tmp/null-resource-hello-world.tfd/provider-for-pre-0.12.tf"
-    fi
+    _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
     mkdir -p "$tmp/rundir"
     cd "$tmp"/rundir
     if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" plan

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -3,6 +3,21 @@
 [ "${DEBUG:-0}" = "1" ] && set -x
 set -u
 
+
+# Detect terraform version (major + minor)
+TF_VER_FULL=$( terraform --version | grep '^Terraform v' | cut -d 'v' -f 2 )
+TF_VER_MAJOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $1}' )
+TF_VER_MINOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $2}' )
+
+# For Terraform < 0.12, the Terraform plugin declaration is different
+if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
+    TF_VER="pre-0.12"
+else
+    TF_VER="post-0.12"
+fi
+
+echo "Terraform Version: $TF_VER_FULL ($TF_VER)"
+
 # Test that plan files don't show up
 _t_plan_files_disabled () {
     pwd
@@ -109,6 +124,15 @@ _t_plan_files_disabled_apply_tfvars () {
 
     rm -rf "$tmp"/local-file-hello-world.tfd
     cp -a "$testsh_pwd/tests/local-file-hello-world.tfd" "$tmp/"
+
+    # Optionally delete the null-provider tf file that we don't need
+    if [ $TF_VER = "pre-0.12" ]; then
+        echo "Using $tmp/local-file-hello-world.tfd/provider-for-pre-0.12.tf"
+    else
+        echo "Deleting $tmp/local-file-hello-world.tfd/provider-for-pre-0.12.tf (not needed)"
+        rm -f "$tmp/local-file-hello-world.tfd/provider-for-pre-0.12.tf"
+    fi
+
     cd "$tmp"/local-file-hello-world.tfd
 
     cat >terraform.sh.tfvars <<EOTFFILE1

--- a/tests/local-file-hello-world.tfd/provider-for-pre-0.12.tf
+++ b/tests/local-file-hello-world.tfd/provider-for-pre-0.12.tf
@@ -1,0 +1,5 @@
+# File to use to pin null_provider when Terraform version < 0.12
+# Note: This file is automatically deleted if Terraform >= 0.12
+provider "local" {
+  version = "1.4.0"
+}

--- a/tests/local-file-hello-world.tfd/provider-for-pre-0.12.tf
+++ b/tests/local-file-hello-world.tfd/provider-for-pre-0.12.tf
@@ -1,4 +1,4 @@
-# File to use to pin null_provider when Terraform version < 0.12
+# File to force local_provider version when Terraform version < 0.12
 # Note: This file is automatically deleted if Terraform >= 0.12
 provider "local" {
   version = "1.4.0"

--- a/tests/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
+++ b/tests/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
@@ -1,4 +1,4 @@
-# File to use to pin null_provider when Terraform version < 0.12
+# File to force null_provider version when Terraform version < 0.12
 # Note: This file is automatically deleted if Terraform >= 0.12
 provider "null" {
   version = "2.1.2"

--- a/tests/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
+++ b/tests/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
@@ -1,0 +1,5 @@
+# File to use to pin null_provider when Terraform version < 0.12
+# Note: This file is automatically deleted if Terraform >= 0.12
+provider "null" {
+  version = "2.1.2"
+}


### PR DESCRIPTION
## Changes

This PR fixes failing tests due to an incompatibility between Terraform version < 0.12 and the `null_provider` and `local_provider`.

I tried different approach to fix the problem, and the simplest way was to create an special provider `.tf` file that is only needed when the test is for Terraform < 0.12.

So when the file is not needed, it gets automatically deleted before running the test.

I was originally hoping to find a better approach, but in the end it's the simplest one and it works fine.

## Tests with different versions

#### Terraform 0.11.15 (the one that was failing originally)

As expected, it downloads the pinned version of `null_provider`.

```bash
$ ./test.sh tests/0001-plan-files-enabled.t &>2 | grep -E "Terraform Version|Downloading|Installing|^Keeping|^Removing|^Terraform|^Plan:|initialized"
Terraform Version: 0.11.15 (pre-0.12)
Keeping version-specific provider file: /home/thomas/tmp/tmp.rbxVXZHzvQ/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Downloading plugin for provider "null" (2.1.2)...
Terraform has been successfully initialized!
Terraform will perform the following actions:
Keeping version-specific provider file: /home/thomas/tmp/tmp.rbxVXZHzvQ/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Downloading plugin for provider "null" (2.1.2)...
Terraform has been successfully initialized!
Terraform will perform the following actions:
```

#### Terraform 0.12.31

As expected, it downloads the latest version of `null_provider`.

```bash
$ ./test.sh tests/0001-plan-files-enabled.t &>2 | grep -E "Terraform Version|Downloading|Installing|^Keeping|^Removing|initialized" 
Terraform Version: 0.12.31 (post-0.12)
Removing unnecessary provider file: /home/thomas/tmp/tmp.fik4RzRKIL/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Downloading plugin for provider "null" (hashicorp/null) 3.2.4...
Terraform has been successfully initialized!
Removing unnecessary provider file: /home/thomas/tmp/tmp.fik4RzRKIL/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Downloading plugin for provider "null" (hashicorp/null) 3.2.4...
Terraform has been successfully initialized!
```

#### Terraform 1.14.4

As expected, it downloads the latest version of `null_provider`.

```bash
$ ./test.sh tests/0001-plan-files-enabled.t &>2 | grep -E "Terraform Version|Downloading|Installing|^Keeping|^Removing|initialized"
Terraform Version: 1.14.4 (post-0.12)
Removing unnecessary provider file: /home/thomas/tmp/tmp.jwDlFvRhSA/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Installing hashicorp/null v3.2.4...
Terraform has been successfully initialized!
Removing unnecessary provider file: /home/thomas/tmp/tmp.jwDlFvRhSA/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
- Installing hashicorp/null v3.2.4...
Terraform has been successfully initialized!
```