### PR TITLE
Improve error detection in tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,9 +23,9 @@ set -u
 
  # Function to delete version-specific tf file that might not be needed based on the TF version
 _check_and_delete_provider_files() {
-    local folder="$1"
-    local tf_ver="$2"
-    if [ ! -z "$folder" ] && [ -d "$folder" ]; then
+    folder="$1"
+    tf_ver="$2"
+    if [ -n "$folder" ] && [ -d "$folder" ]; then
         # Based on the TF version, keep or delete specific files
         if [ "$tf_ver" = "pre-0.12" ]; then
             find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Keeping version-specific provider file: {}" \;
@@ -45,6 +45,8 @@ _main () {
     . "tests/0000-pre-req-detect-tf-version.sh"
 
     for i in "$@" ; do
+
+        echo "======================================================================"
 
         cd "$testsh_pwd"
 
@@ -77,6 +79,8 @@ _main () {
         _pass=$(($_pass+$pass))
 
     done
+
+    echo "======================================================================"
 }
 
 _main "$@"

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -25,6 +25,10 @@ _t_plan_files_enabled () {
             ls -la
             return 1
         fi
+    else
+        echo "$base_name: ERROR: terraformsh returned error!"
+        ls -la
+        return 1
     fi
 }
 
@@ -51,6 +55,10 @@ _t_plan_files_enabled_cd_dir () {
             ls -la
             return 1
         fi
+    else
+        echo "$base_name: ERROR: terraformsh returned error!"
+        ls -la "$tmp/null-resource-hello-world.tfd"
+        return 1
     fi
 }
 

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -47,7 +47,7 @@ _t_plan_files_disabled_cd_dir () {
     mkdir -p "$tmp/rundir"
     cd "$tmp"/rundir
 
-    if      $testsh_pwd/terraformsh -c "$tmp/null-resource-hello-world.tfd" -P plan
+    if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" -P plan
     then
 
         TERRAFORM_PWD="$(pwd)"

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -28,6 +28,10 @@ _t_plan_files_disabled () {
             ls -la
             return 1
         fi
+    else
+        echo "$base_name: ERROR: terraformsh returned error!"
+        ls -la
+        return 1
     fi
 }
 
@@ -59,6 +63,10 @@ _t_plan_files_disabled_cd_dir () {
             ls -la
             return 1
         fi
+    else
+        echo "$base_name: ERROR: terraformsh returned error!"
+        ls -la "$tmp/null-resource-hello-world.tfd"
+        return 1
     fi
 }
 
@@ -99,6 +107,10 @@ _t_plan_files_disabled_destroy () {
             ls -la
             return 1
         fi
+    else
+        echo "$base_name: ERROR: terraformsh returned error!"
+        ls -la
+        return 1
     fi
 }
 


### PR DESCRIPTION
#### Changes

- Ensures that we always verify the exit code of `terraformsh` during the tests.
- Add a delimiter so we can more easily see the different tests' output more easily.
- Fix minor warning in `shellcheck`

#### Why ?

I have realized that there was a test that was failing on the `terraformsh` command itself, but we were not catching that error because we were not always checking for the exit code of `terraformsh`.

I think that this test might have been failing for a while, but we never saw it.

The test that seems to fail on `terraformsh` itself is:

```
/home/thomas/tmp/tmp.UxB2uKeXpf/null-resource-hello-world.tfd
Removing unnecessary provider file: /home/thomas/tmp/tmp.UxB2uKeXpf/null-resource-hello-world.tfd/provider-for-pre-0.12.tf
/home/thomas/github/Th0masL/terraformsh/terraformsh: line 556: .: /home/thomas/tmp/tmp.UxB2uKeXpf/null-resource-hello-world.tfd: is a directory
0002-plan-files-disabled: ERROR: terraformsh returned error!
total 16
drwxrwxr-x 2 tlejeune tlejeune 4096 Feb  8 00:46 .
drwx------ 4 tlejeune tlejeune 4096 Feb  8 00:46 ..
-rw-rw-r-- 1 tlejeune tlejeune  283 Feb  5 00:53 null-hello-goodbye.tf
-rw-rw-r-- 1 tlejeune tlejeune    7 Feb  4 22:19 .terraform-version
./test.sh: 0002-plan-files-disabled: Test plan_files_disabled_cd_dir failed
```

