### PR TITLE
Refactor configuration loading in terraformsh

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -544,16 +544,22 @@ _final_vars () {
 }
 _load_conf () {
     # Don't load the default configs if one was passed via '-c'
+    declare -a _tmp_confs=()
     if [ ${#CONF_FILE[@]} -lt 1 ] ; then
-        for f in "/etc/terraformsh" ~/.terraformshrc "./.terraformshrc" "terraformsh.conf" ; do
-            [ -e "$f" ] && . "$(_readlinkf "$f")"
-        done
+        _tmp_confs=("/etc/terraformsh" ~/.terraformshrc "./.terraformshrc" "./terraformsh.conf")
     # If '-c' was passed, let the user pass only the configs they want to load.
     elif [ ${#CONF_FILE[@]} -gt 0 ] ; then
-        for conf in "${CONF_FILE[@]}" ; do
-            # NOTE: This is not a replacement for 'readlink -f'; if you want
-            # that behavior, pass the real file path yourself, don't rely on this.
-            . "$(_readlinkf "$conf")"
+        _tmp_confs=("${CONF_FILE[@]}")
+    fi
+    for conf in "${_tmp_confs[@]}" ; do
+        if [ -d "$conf" ] ; then
+            _errexit "Config file '$conf' is a directory! Exiting"
+        elif [ ! -r "$conf" ] ; then
+            _errexit "Error: could not read conf file '$conf'! Exiting"
+        fi
+        # NOTE: This is not a replacement for 'readlink -f'; if you want
+        # that behavior, pass the real file path yourself, don't rely on this.
+        . "$(_readlinkf "$conf")"
         done
     fi
     return 0

--- a/terraformsh
+++ b/terraformsh
@@ -560,7 +560,6 @@ _load_conf () {
         # NOTE: This is not a replacement for 'readlink -f'; if you want
         # that behavior, pass the real file path yourself, don't rely on this.
         . "$(_readlinkf "$conf")"
-        done
     done
     return 0
 }

--- a/terraformsh
+++ b/terraformsh
@@ -543,18 +543,26 @@ _final_vars () {
     _final_vars_set=1
 }
 _load_conf () {
-    # Don't load the default configs if one was passed via '-c'
+    local _usedefaultconf=1
     declare -a _tmp_confs=()
     if [ ${#CONF_FILE[@]} -lt 1 ] ; then
         _tmp_confs=("/etc/terraformsh" ~/.terraformshrc "./.terraformshrc" "./terraformsh.conf")
-    # If '-c' was passed, let the user pass only the configs they want to load.
     elif [ ${#CONF_FILE[@]} -gt 0 ] ; then
+        _usedefaultconf=0
         _tmp_confs=("${CONF_FILE[@]}")
     fi
     for conf in "${_tmp_confs[@]}" ; do
         if [ -d "$conf" ] ; then
             _errexit "Config file '$conf' is a directory! Exiting"
-        elif [ ! -r "$conf" ] ; then
+        elif [ "$_usedefaultconf" -eq 0 ] && [ ! -e "$conf" ] ; then
+            # If conf file was explicitly specified, it must exist and be readable
+            _errexit "Error: could not find conf file '$conf'! Exiting"
+        elif [ "$_usedefaultconf" -eq 1 ] && [ ! -e "$conf" ] ; then
+            # If using default conf files, just skip nonexistent ones
+            continue
+        fi
+        # If conf file exists, it must be readable
+        if [ ! -r "$conf" ] ; then
             _errexit "Error: could not read conf file '$conf'! Exiting"
         fi
         # NOTE: This is not a replacement for 'readlink -f'; if you want

--- a/terraformsh
+++ b/terraformsh
@@ -561,7 +561,7 @@ _load_conf () {
         # that behavior, pass the real file path yourself, don't rely on this.
         . "$(_readlinkf "$conf")"
         done
-    fi
+    done
     return 0
 }
 _load_parent_tffiles () {


### PR DESCRIPTION
Saw a bug (guess it wasn't a bug really) where terraformsh died while trying to load a directory as a config file. The error message wasn't clear, so it made diagnosing the issue more difficult.

This change does the following:

 - DRY the two separate sets of logic into one. Use a temporary array to iterate over confs depending on what was passed.

 - Expand the logic a bit to check whether the configs used are defaults or not; if using defaults, non-existent files are skipped, but existent non-readable files and directories are errored on. For non-default configs, they must both exist, be readable, and not be directories, or we error out.