### PR TITLE
Lint and shellcheck tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -27,10 +27,10 @@ _check_and_delete_provider_files() {
     tf_ver="$2"
     if [ -n "$folder" ] && [ -d "$folder" ]; then
         # Based on the TF version, keep or delete specific files
-        if [ "$tf_ver" = "pre-0.12" ]; then
-            find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Keeping version-specific provider file: {}" \;
-        else
+        if [ "$tf_ver" != "pre-0.12" ]; then
             find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Removing unnecessary provider file: {}" \; -delete
+        else
+            find "$folder" -maxdepth 1 -type f -name "*-pre-0.12.tf" -exec echo "Keeping version-specific provider file: {}" \;
         fi
     fi
 }
@@ -48,7 +48,7 @@ _main () {
 
         echo "======================================================================"
 
-        cd "$testsh_pwd"
+        cd "$testsh_pwd" || exit 1
 
         # The following variables should be used by *.t scripts
         base_name="$(basename "$i" .t)"     ### So you don't need ${BASH_SOURCE[0]}

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -8,7 +8,7 @@ _t_plan_files_enabled () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
-    cd "$tmp"/null-resource-hello-world.tfd || exit 1
+    cd "$tmp"/null-resource-hello-world.tfd || return 1
     if      $testsh_pwd/terraformsh plan
     then
 
@@ -38,7 +38,7 @@ _t_plan_files_enabled_cd_dir () {
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
     mkdir -p "$tmp/rundir"
-    cd "$tmp"/rundir || exit 1
+    cd "$tmp"/rundir || return 1
     if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" plan
     then
 

--- a/tests/0001-plan-files-enabled.t
+++ b/tests/0001-plan-files-enabled.t
@@ -8,7 +8,7 @@ _t_plan_files_enabled () {
     pwd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
-    cd "$tmp"/null-resource-hello-world.tfd
+    cd "$tmp"/null-resource-hello-world.tfd || exit 1
     if      $testsh_pwd/terraformsh plan
     then
 
@@ -38,7 +38,7 @@ _t_plan_files_enabled_cd_dir () {
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
     mkdir -p "$tmp/rundir"
-    cd "$tmp"/rundir
+    cd "$tmp"/rundir || exit 1
     if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" plan
     then
 

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -45,7 +45,7 @@ _t_plan_files_disabled_cd_dir () {
 
     rm -rf "$tmp"/rundir
     mkdir -p "$tmp/rundir"
-    cd "$tmp"/rundir
+    cd "$tmp"/rundir || return 1
 
     if      $testsh_pwd/terraformsh -C "$tmp/null-resource-hello-world.tfd" -P plan
     then
@@ -81,7 +81,7 @@ _t_plan_files_disabled_destroy () {
     rm -rf "$tmp"/null-resource-hello-world.tfd
     cp -a "$testsh_pwd/tests/null-resource-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/null-resource-hello-world.tfd" "$TF_VER"
-    cd "$tmp"/null-resource-hello-world.tfd
+    cd "$tmp"/null-resource-hello-world.tfd || return 1
 
     set -e
 
@@ -125,7 +125,7 @@ _t_plan_files_disabled_apply_tfvars () {
     rm -rf "$tmp"/local-file-hello-world.tfd
     cp -a "$testsh_pwd/tests/local-file-hello-world.tfd" "$tmp/"
     _check_and_delete_provider_files "$tmp/local-file-hello-world.tfd" "$TF_VER"
-    cd "$tmp"/local-file-hello-world.tfd
+    cd "$tmp"/local-file-hello-world.tfd || return 1
 
     cat >terraform.sh.tfvars <<EOTFFILE1
 insert-value = "(this is from the tfvars file)"

--- a/tests/0002-plan-files-disabled.t
+++ b/tests/0002-plan-files-disabled.t
@@ -85,7 +85,7 @@ _t_plan_files_disabled_destroy () {
 
     set -e
 
-    if     $testsh_pwd/terraformsh -P -E "DESTROY_ARGS+=(-auto-approve)" destroy 2>&1 | tee test.log
+    if      $testsh_pwd/terraformsh -P -E "DESTROY_ARGS+=(-auto-approve)" destroy 2>&1 | tee test.log
     then
 
         # Check for 'apply'

--- a/tests/0006-apply-no-tfvars.t
+++ b/tests/0006-apply-no-tfvars.t
@@ -8,7 +8,7 @@ _t_apply_no_tfvars () {
 
     rm -rf "$tmp"/local-file-hello-world.tfd
     cp -a "$testsh_pwd/tests/local-file-hello-world.tfd" "$tmp/"
-    cd "$tmp"/local-file-hello-world.tfd || exit 1
+    cd "$tmp"/local-file-hello-world.tfd || return 1
 
     if      $testsh_pwd/terraformsh plan apply
     then

--- a/tests/0006-apply-no-tfvars.t
+++ b/tests/0006-apply-no-tfvars.t
@@ -8,7 +8,7 @@ _t_apply_no_tfvars () {
 
     rm -rf "$tmp"/local-file-hello-world.tfd
     cp -a "$testsh_pwd/tests/local-file-hello-world.tfd" "$tmp/"
-    cd "$tmp"/local-file-hello-world.tfd
+    cd "$tmp"/local-file-hello-world.tfd || exit 1
 
     if      $testsh_pwd/terraformsh plan apply
     then


### PR DESCRIPTION
This PR is a preparation for a PR that will support running tests with the OpenTofu binary.

Changes are:
- lint / fixes shellcheck warning in tests files
- invert the `if` logic for keeping/deleting files that are for `pre-0.12`, as it's more flexible to also be compatible with OpenTofu