### PR TITLE
Add CI tests for OpenTofu

### DIFF
--- a/.github/actions/opentofu-version-runner/Dockerfile
+++ b/.github/actions/opentofu-version-runner/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:stable-slim
+
+ARG VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        jq \
+        git \
+        make \
+        unzip \
+        sudo \
+        shellcheck \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Load the version to install from the file and install it
+RUN wget -O tofu_amd64.deb "https://github.com/opentofu/opentofu/releases/download/v${VERSION}/tofu_${VERSION}_amd64.deb" \
+    && dpkg -i tofu_amd64.deb \
+    && rm -rf tofu_amd64.deb
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/.github/actions/opentofu-version-runner/Dockerfile
+++ b/.github/actions/opentofu-version-runner/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
-        jq \
         git \
         make \
         unzip \
@@ -17,7 +16,6 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Load the version to install from the file and install it
 RUN wget -O tofu_amd64.deb "https://github.com/opentofu/opentofu/releases/download/v${VERSION}/tofu_${VERSION}_amd64.deb" \
     && dpkg -i tofu_amd64.deb \
     && rm -rf tofu_amd64.deb

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,6 @@ name: Continuous Integration
 
 on:
 
-  # Enable this block when testing on custom branches
-  push:
-    branches: [ test-github-actions-branch ]
-
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           build-args: "TFVER=${{ matrix.version }}"
 
       - name: Run test suite
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: "local-terraform:${{ matrix.version }}"
           options: "-v ${{ github.workspace }}:/work -w /work"
@@ -95,7 +95,7 @@ jobs:
           build-args: "VERSION=${{ matrix.version }}"
 
       - name: Run test suite
-        uses: addnab/docker-run-action@v3
+        uses: maus007/docker-run-action-fork@v1
         with:
           image: "local-opentofu:${{ matrix.version }}"
           options: "-v ${{ github.workspace }}:/work -w /work"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,19 @@
 name: Continuous Integration
 
 on:
-  #push:
+
+  # Enable this block when testing on custom branches
+  push:
+    branches: [ test-github-actions-branch ]
+
   pull_request:
     branches: [ main ]
 
 jobs:
-  test_pull_request:
-    name: Run tests on a pull request
+
+  test_pull_request_terraform:
+
+    name: Run tests with Terraform
     runs-on: ubuntu-latest
 
     strategy:
@@ -24,20 +30,20 @@ jobs:
           - "1.3.10"
           - "1.4.7"
           - "1.5.7"
-          - "1.6.3"
+          - "1.6.6"
+          - "1.7.5"
+          - "1.8.5"
+          - "1.9.8"
+          - "1.10.5"
+          - "1.11.4"
+          - "1.12.2"
+          - "1.13.5"
+          - "1.14.4"
 
     steps:
 
       - name: Checkout git
         uses: actions/checkout@v2
-
-      #- name: Build container
-      #  uses: ./.github/actions/terraform-version-runner
-      #  with:
-      #    terraform-version: "${{ matrix.version }}"
-      #  env:
-      #    DEBUG: 1
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
@@ -59,3 +65,44 @@ jobs:
           run: |
               terraform --version
               make
+
+  test_pull_request_opentofu:
+
+    name: Run tests with OpenTofu
+    runs-on: ubuntu-latest
+    needs: test_pull_request_terraform
+
+    strategy:
+      matrix:
+        version:
+          - "1.7.10"
+          - "1.8.11"
+          - "1.9.3"
+          - "1.10.8"
+          - "1.11.4"
+
+    steps:
+
+      - name: Checkout git
+        uses: actions/checkout@v2
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ".github/actions/opentofu-version-runner/Dockerfile"
+          tags: "local-opentofu:${{ matrix.version }}"
+          load: true
+          cache-from: "type=gha"
+          cache-to: "type=gha,mode=max"
+          push: false
+          build-args: "VERSION=${{ matrix.version }}"
+
+      - name: Run test suite
+        uses: addnab/docker-run-action@v3
+        with:
+          image: "local-opentofu:${{ matrix.version }}"
+          options: "-v ${{ github.workspace }}:/work -w /work"
+          run: |
+              tofu --version
+              TERRAFORM=tofu make

--- a/tests/0000-pre-req-detect-tf-version.sh
+++ b/tests/0000-pre-req-detect-tf-version.sh
@@ -3,16 +3,31 @@
 [ "${DEBUG:-0}" = "1" ] && set -x
 set -u
 
+if [ -n "$( which terraform 2>/dev/null )" ]; then
+    TERRAFORM_SHORT_NAME="terraform"
+elif [ -n "$( which tofu 2>/dev/null )" ]; then
+    TERRAFORM_SHORT_NAME="tofu"
+else
+    echo "Error: Unable to find terraform or tofu."
+    exit 1
+fi
+
 # Detect terraform version (major + minor)
-TF_VER_FULL=$( terraform --version | grep '^Terraform v' | cut -d 'v' -f 2 )
+TF_VER_OUTPUT=$( $TERRAFORM_SHORT_NAME --version | grep -E '^Terraform v|^OpenTofu v' | head -1 )
+TERRAFORM_NICE_NAME=$( echo "$TF_VER_OUTPUT" | awk '{print $1}' ) 
+TF_VER_FULL=$( echo "$TF_VER_OUTPUT" | awk '{print $2}' | tr -d 'v' )
 TF_VER_MAJOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $1}' )
 TF_VER_MINOR=$( echo "$TF_VER_FULL" | awk -F '.' '{print $2}' )
 
 # For Terraform < 0.12, the Terraform plugin declaration is different
-if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
-    TF_VER="pre-0.12"
+if [ "$TERRAFORM_SHORT_NAME" = "terraform" ]; then
+    if [ $TF_VER_MAJOR -eq 0 ] && [ $TF_VER_MINOR -lt 12 ]; then
+        TF_VER="pre-0.12"
+    else
+        TF_VER="post-0.12"
+    fi
 else
-    TF_VER="post-0.12"
+    TF_VER="$TF_VER_MAJOR.$TF_VER_MINOR"
 fi
 
-echo "Terraform Version: $TF_VER_FULL ($TF_VER)"
+echo "$TERRAFORM_NICE_NAME Version: $TF_VER_FULL ($TF_VER)"

--- a/tests/0006-apply-no-tfvars.t
+++ b/tests/0006-apply-no-tfvars.t
@@ -8,6 +8,7 @@ _t_apply_no_tfvars () {
 
     rm -rf "$tmp"/local-file-hello-world.tfd
     cp -a "$testsh_pwd/tests/local-file-hello-world.tfd" "$tmp/"
+    _check_and_delete_provider_files "$tmp/local-file-hello-world.tfd" "$TF_VER"
     cd "$tmp"/local-file-hello-world.tfd || return 1
 
     if      $testsh_pwd/terraformsh plan apply


### PR DESCRIPTION
This PR adds tests for OpenTofu.

I have also updated the list of versions for Terraform, but I think it might be overkill to test every single minor version.