### PR TITLE
Autodetect terraform or tofu executable based on what is installed

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -472,7 +472,6 @@ _default_vars () {
     CD_DIR=""
     QUIET_MODE=0
     USE_PLANFILE="${USE_PLANFILE:-1}"
-    TERRAFORM="${TERRAFORM:-terraform}" # the terraform executable
     PLAN_ARGS=("-input=false")
     APPLY_ARGS=("-input=false")
     PLANDESTROY_ARGS=("-input=false")
@@ -493,6 +492,18 @@ _default_vars () {
     FORCEUNLOCK_ARGS=("-force")
     SHOW_ARGS=()
 
+    # Set TERRAFORM to user-provided value, or detect available binary
+    if [ -z "${TERRAFORM:-}" ]; then
+        if command -v terraform >/dev/null 2>&1; then
+            TERRAFORM="terraform"
+        elif command -v tofu >/dev/null 2>&1; then
+            TERRAFORM="tofu"
+        else
+            _stderrlog "Error: 'TERRAFORM' environment variable is not set, and neither 'terraform' nor 'tofu' binary was found in PATH."
+            return 1
+        fi
+    fi
+
     # Detect the name of the Terraform/OpenTofu binary
     if [ -z "${TERRAFORM_NICE_NAME:-}" ] || [ -z "${TERRAFORM_SHORT_NAME:-}" ] ; then
         TERRAFORM_NICE_NAME="$($TERRAFORM --version | grep -E '^Terraform v|^OpenTofu v' | cut -d ' ' -f 1)"
@@ -505,7 +516,7 @@ _default_vars () {
             OpenTofu) TERRAFORM_SHORT_NAME="tofu" ;;
         esac
     fi
-    
+
     TERRAFORM_PWD="$(pwd)"
 }
 _pre_dirchange_vars () {


### PR DESCRIPTION
One can make the assumption that most people will either use Terraform or OpenTofu, but rarely both.

The main reason being that:
- most people that switched to OpenTofu did so because of the HashiCorp license change, and probably have no plan to ever switch back to Terraform
- most people that are still using Terraform don't care about the HashiCorp license change (or are not aware about it), and therefore probably don't plan to switch to OpenTofu anytime soon

So this PR allows to automatically detect the best binary to use, in the following order of preference:

1. User provided `TERRAFORM` Env Var
2. `terraform` binary (if found)
3. `tofu` binary (if found)
4. Exit with an error

For anyone that wants to be able to use both binaries depending on their project, nothing is changing for them, they will have to continue to call with `TERRAFORM=<name> terraformsh`.
