### PR TITLE
Preserve spaces during parent config discovery

### DIFF
--- a/terraformsh
+++ b/terraformsh
@@ -809,7 +809,7 @@ _rfindfiles () {
     cwd="$(pwd)"
     while [ ! "$(dirname "$cwd")" = "/" ] ; do
         for f in "$@" ; do
-            for p in $cwd/$f ; do
+            for p in "$cwd"/$f ; do
                 if [ ! -d "$p" ] && [ -e "$p" ] ; then
                     printf "%s\n" "$p"
                 fi

--- a/tests/0008-rfindfiles-space-path.t
+++ b/tests/0008-rfindfiles-space-path.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC2034,SC2154 # Variables are supplied/consumed by test.sh.
+# vim: syntax=sh
+[ "${DEBUG:-0}" = "1" ] && set -x
+set -u
+
+_t_inherits_tfvars_from_path_with_spaces () {
+    parent="$tmp/parent with space"
+    module="$parent/module"
+    mkdir -p "$module" || return 1
+    printf '%s\n' 'example = "inherited"' > "$parent/terraform.sh.tfvars"
+    cd "$module" || return 1
+
+    output="$("$testsh_pwd/terraformsh" -N -D -P plan 2>&1)"
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        echo "$base_name: ERROR: terraformsh returned $status"
+        echo "$output"
+        return 1
+    fi
+
+    expected="-var-file $parent/terraform.sh.tfvars"
+    if ! printf '%s\n' "$output" | grep -F -- "$expected" >/dev/null; then
+        echo "$base_name: ERROR: inherited tfvars were omitted from a path containing spaces"
+        echo "Expected output to contain: $expected"
+        echo "$output"
+        return 1
+    fi
+}
+
+ext_tests="inherits_tfvars_from_path_with_spaces"


### PR DESCRIPTION
## Summary

Preserve spaces during parent config discovery.

Finding: `09`  
Priority: `P1 / Medium`

## Regression evidence

The same regression test was run against the PR base and this branch:

- `09_space_path` fails against base commit `d0a01c31598c739b03a40d065a7efbb92a3570dd`.
- `09_space_path` passes on this branch.

## Validation

- [x] Regression fails on the unmodified base
- [x] Regression passes with the fix
- [x] ShellCheck passes
- [x] Full upstream test suite
